### PR TITLE
Fix DEFAULT_DELAY environment variable support and timing

### DIFF
--- a/clt
+++ b/clt
@@ -33,7 +33,8 @@ DOCKER_PROJECT_DIR='/.clt'
 export PROJECT_DIR DOCKER_PROJECT_DIR
 
 # Set the default delay in ms between each command in the given test
-export DEFAULT_DELAY=5
+# Use environment variable if set, otherwise default to 5ms
+export DEFAULT_DELAY=${DEFAULT_DELAY:-5}
 
 case "$cmd" in
 	record)


### PR DESCRIPTION
1. Allow DEFAULT_DELAY to be set via environment variable
   - Changed from hardcoded 'export DEFAULT_DELAY=5' to 'export DEFAULT_DELAY=${DEFAULT_DELAY:-5}'
   - This allows users to override the default delay using -e DEFAULT_DELAY=<value>

2. Move delay sleep before command execution instead of after
   - Previously: execute command → read output → write to file → sleep
   - Now: sleep → execute command → read output → write to file
   - This ensures the delay happens between commands, giving time for async operations (like log writes) to complete
   - Skip sleep for the first command to avoid unnecessary wait