### PR TITLE
fix: comment_mode string comparison bug

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -238,8 +238,12 @@ runs:
 
         should_comment="$should_exit"
         if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-          if [ "${{ inputs.comment_mode }}" -eq 'always' ]; then
+          if [ "${{ inputs.comment_mode }}" == 'always' ]; then
             should_comment=1
+          elif [ "${{ inputs.comment_mode }}" == 'failures' ]; then
+            should_comment="$should_exit"
+          else
+            should_comment=0
           fi
         else
           should_comment=0


### PR DESCRIPTION
Changed `-eq` to `==` when comparing comment_mode input value. The `-eq` operator is for numeric comparison and caused "integer expression expected" error when comment_mode was set to 'failures'.

Also added proper handling for 'failures' mode to only comment when tests fail.

The related CI job where it failed is https://github.com/manticoresoftware/manticoresearch/actions/runs/21181454173/job/60967520091?pr=4165